### PR TITLE
fix: :safety_vest: Safety check for logW value

### DIFF
--- a/xmss/params.go
+++ b/xmss/params.go
@@ -29,6 +29,9 @@ type XMSSParams struct {
 
 func NewWOTSParams(n, w uint32) *WOTSParams {
 	logW := uint32(math.Log2(float64(w)))
+	if logW != 2 && logW != 4 && logW != 8 {
+		panic("logW should be either 2, 4 or 8")
+	}
 	len1 := uint32(math.Ceil(float64((8 * n) / logW)))
 	len2 := uint32(math.Floor(math.Log2(float64(len1*(w-1)))/float64(logW)) + 1)
 	totalLen := len1 + len2


### PR DESCRIPTION
- Ensures the value of logW is 2, 4 or 8
- If not, an error will be raised.

![Screenshot from 2024-05-24 10-00-55](https://github.com/theQRL/go-qrllib/assets/10585474/837140ef-cc00-4117-bf68-1b2d3d4e4ca5)
