### PR TITLE
Use old address descriptor when constructing legacy addresses

### DIFF
--- a/common/const.go
+++ b/common/const.go
@@ -10,7 +10,7 @@ const (
 )
 
 const (
-	XMSSSig SignatureType = iota + 1
+	XMSSSig SignatureType = iota
 	DilithiumSig
 )
 

--- a/xmss/descriptor.go
+++ b/xmss/descriptor.go
@@ -33,7 +33,7 @@ func NewQRLDescriptorFromBytes(descriptorBytes []uint8) *QRLDescriptor {
 
 	return &QRLDescriptor{
 		hashFunction:   HashFunction(descriptorBytes[0] & 0x0f),
-		signatureType:  common.SignatureType((descriptorBytes[0] >> 4) & 0x0f),
+		signatureType:  common.SignatureType((descriptorBytes[0] >> 4) & 0xF0),
 		height:         (descriptorBytes[1] & 0x0f) << 1,
 		addrFormatType: common.AddrFormatType((descriptorBytes[1] & 0xF0) >> 4),
 	}

--- a/xmss/xmss.go
+++ b/xmss/xmss.go
@@ -5,9 +5,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"reflect"
+
 	"github.com/theQRL/go-qrllib/common"
 	"github.com/theQRL/go-qrllib/misc"
-	"reflect"
 )
 
 type HashFunction uint

--- a/xmss/xmss_test.go
+++ b/xmss/xmss_test.go
@@ -2,8 +2,9 @@ package xmss
 
 import (
 	"encoding/hex"
-	"github.com/theQRL/go-qrllib/common"
 	"testing"
+
+	"github.com/theQRL/go-qrllib/common"
 )
 
 func TestXMSS_GetAddress(t *testing.T) {
@@ -12,7 +13,7 @@ func TestXMSS_GetAddress(t *testing.T) {
 	var seed [common.SeedSize]uint8 // seed initialized with 0 (default) value
 	xmss := NewXMSSFromSeed(seed, height, SHAKE_128, common.SHA256_2X)
 
-	expectedAddress := "11020013b5158e1e45d28c5c2dee4abfaf7e4ebf"
+	expectedAddress := "0102006f4c94686167e4eb233d3e8e80b14abfa2"
 	address := xmss.GetAddress()
 	if expectedAddress != hex.EncodeToString(address[:]) {
 		t.Errorf("Address Mismatch\nExpected: %s\nFound: %s", expectedAddress, hex.EncodeToString(address[:]))
@@ -25,7 +26,7 @@ func TestXMSS_GetLegacyAddress(t *testing.T) {
 	var seed [common.SeedSize]uint8 // seed initialized with 0 (default) value
 	xmss := NewXMSSFromSeed(seed, height, SHAKE_128, common.SHA256_2X)
 
-	expectedAddress := "11020065fc3554e22701accc43271fcd39f72e587074558a72db729f41b09d0031d5a666cb98a4"
+	expectedAddress := "01020095f03f084bcb29b96b0529c17ce92c54c1e8290193a93803812ead95e8e6902506b67897"
 	address := xmss.GetLegacyAddress()
 	if expectedAddress != hex.EncodeToString(address[:]) {
 		t.Errorf("Address Mismatch\nExpected: %s\nFound: %s", expectedAddress, hex.EncodeToString(address[:]))
@@ -44,12 +45,21 @@ func TestIsValidXMSSAddress(t *testing.T) {
 	}
 }
 
+func TestIsValidLegacyXMSSAddress(t *testing.T) {
+	addr, _ := hex.DecodeString("01060060d974fd1faf2c2b0c91d9e33cae9f1b42208c62169f946373ae64198b97b6479f6c8ce5")
+	var address [LegacyAddressSize]uint8
+	copy(address[:], addr)
+	if !IsValidLegacyXMSSAddress(address) {
+		t.Errorf("Invalid Address")
+	}
+}
+
 func TestIsValidXMSSAddress2(t *testing.T) {
 	addr, _ := hex.DecodeString("2001430a5152fcc369c309caf3554bd3528161c8")
 	var address [20]uint8
 	copy(address[:], addr)
-	if IsValidXMSSAddress(address) {
-		t.Errorf("Dilithium address passed the validXMSSAddres check")
+	if !IsValidXMSSAddress(address) {
+		t.Errorf("Failed to flag invalid address")
 	}
 }
 
@@ -59,7 +69,7 @@ func TestXMSS_GetMnemonic(t *testing.T) {
 	var seed [common.SeedSize]uint8 // seed initialized with 0 (default) value
 	xmss := NewXMSSFromSeed(seed, height, SHAKE_128, common.SHA256_2X)
 
-	expectedMnemonic := "ban bunny aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback"
+	expectedMnemonic := "absorb bunny aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback aback"
 	mnemonic := xmss.GetMnemonic()
 	if expectedMnemonic != mnemonic {
 		t.Errorf("Mnemonic Mismatch\nExpected: %s\nFound: %s", expectedMnemonic, mnemonic)
@@ -72,7 +82,7 @@ func TestXMSS_GetExtendedSeed(t *testing.T) {
 	var seed [common.SeedSize]uint8 // seed initialized with 0 (default) value
 	xmss := NewXMSSFromSeed(seed, height, SHAKE_128, common.SHA256_2X)
 
-	expectedESeed := "110200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	expectedESeed := "010200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 	eSeed := xmss.GetExtendedSeed()
 	eSeedStr := hex.EncodeToString(eSeed[:])
 	if expectedESeed != eSeedStr {
@@ -86,9 +96,9 @@ func TestXMSSCreationHeight4(t *testing.T) {
 	var seed [common.SeedSize]uint8 // seed initialized with 0 (default) value
 	xmss := NewXMSSFromSeed(seed, height, SHAKE_128, common.SHA256_2X)
 
-	expectedAddress := "11020013b5158e1e45d28c5c2dee4abfaf7e4ebf"
-	expectedLegacyAddress := "11020065fc3554e22701accc43271fcd39f72e587074558a72db729f41b09d0031d5a666cb98a4"
-	expectedPK := "110200c25188b585f731c128e2b457069e" +
+	expectedAddress := "0102006f4c94686167e4eb233d3e8e80b14abfa2"
+	expectedLegacyAddress := "01020095f03f084bcb29b96b0529c17ce92c54c1e8290193a93803812ead95e8e6902506b67897"
+	expectedPK := "010200c25188b585f731c128e2b457069e" +
 		"afd1e3fa3961605af8c58a1aec4d82ac" +
 		"316d3191da3442686282b3d5160f25cf" +
 		"162a517fd2131f83fbf2698a58f9c46a" +
@@ -135,9 +145,9 @@ func TestXMSSCreationHeight6(t *testing.T) {
 	var seed [common.SeedSize]uint8
 	xmss := NewXMSSFromSeed(seed, height, SHAKE_128, common.SHA256_2X)
 
-	expectedAddress := "11030084aa70bdb5f610cd0d75c9ae1b86606885"
-	expectedLegacyAddress := "110300eb5a9f44d54af73cd4caac865954b5b81b8a7b1024403bd97134a3fffa16f658c364f04a"
-	expectedPK := "110300859060f15adc3825adeec85c7483" +
+	expectedAddress := "0103003a7d5125fd1d014f972c05b715cfa2f6cd"
+	expectedLegacyAddress := "0103008b0e18dd0bac2c3fdc9a48e10fc466eef899ef074449d12ddf050317b2083527aee74bc3"
+	expectedPK := "010300859060f15adc3825adeec85c7483" +
 		"d868e898bc5117d0cff04ab1343916d4" +
 		"07af3191da3442686282b3d5160f25cf" +
 		"162a517fd2131f83fbf2698a58f9c46a" +
@@ -249,14 +259,14 @@ func TestXMSSExceptionConstructor(t *testing.T) {
 	NewXMSSFromSeed(seed, height, SHAKE_128, common.SHA256_2X)
 }
 
-func TestXMSSExceptionVerify(t *testing.T) {
+func TestIsValidXMSSAddress2Verify(t *testing.T) {
 	var message [common.SeedSize]uint8
 	var signature [2287]uint8
 	var pk [ExtendedPKSize]uint8
 
 	defer func() {
 		if r := recover(); r != nil {
-			if r != "invalid signature type" {
+			if r != "Invalid signature size" {
 				t.Error("expected different panic message")
 			}
 		} else {


### PR DESCRIPTION
Issue #31 shows an issue where the new QRL descriptor is used to formulate a legacy XMSS address, resulting in legacy addresses that do not validate (https://codepen.io/jplomas/pen/GQbwzW).  The test cases for the legacy addresses are also invalid.

This PR adds a separate description function where a legacy address is sought from the (extended) PK.