### PR TITLE
Limit XMSS MaxHeight to 30

### DIFF
--- a/xmss/xmss.go
+++ b/xmss/xmss.go
@@ -28,7 +28,7 @@ const (
 )
 
 const (
-	MaxHeight = 254
+	MaxHeight = 30 // MaxHeight set to 30, as lastNode datatype is uint32 anything more than height 30 will result into overflow
 )
 
 const (


### PR DESCRIPTION
XMSS MaxHeight limited to 30, as the code (including original c++ code) has datatype of some variables deriving value from height which will result into overflow for height above 30